### PR TITLE
Fixes the path issues with data/sumary.psk

### DIFF
--- a/MainFrame.h
+++ b/MainFrame.h
@@ -12,14 +12,13 @@
 #include <cryptopp/integer.h>
 #include <cryptopp/algebra.h>
 
-
 class MainFrame : public wxFrame
 {
-public: 
+public:
 	MainFrame(const wxString& title);
 	std::string MasterNodeListString="Empty";
 	std::string GeneratedNosoAddress = "Empty";
-	
+
 
 private:
 
@@ -39,8 +38,8 @@ private:
 	std::string SignMessage(const std::string& message, const CryptoPP::ECDSA<CryptoPP::ECP, CryptoPP::SHA256>::PrivateKey& privateKey);
 	bool VerifyMessage(const std::string& message, const std::string& signature, const CryptoPP::ECDSA<CryptoPP::ECP, CryptoPP::SHA256>::PublicKey& publicKey);
 
-	
-	
+
+
 	//Time Sync NTP
 	wxStaticText* CurrentBlock;
 	wxStaticText* GetSumaryText;
@@ -48,11 +47,11 @@ private:
 	//Noso Addresses Control
 	wxStaticText* TotalNosoAddressesLoadedText;
 	wxStaticText* TotalNosoAddressesLoadedValue;
-	
+
 	//Time Controls
 
 	wxStaticText* MainNetTimeText;
-    wxTimer* Timer;
+        wxTimer* Timer;
 	void OnTimer(wxTimerEvent& event);
 
 	//MasterNode List
@@ -69,7 +68,7 @@ private:
 	wxStaticText* GenerateNOSOAddressText;
 
 
- 
+
 
 
 };

--- a/NosoWalletCPP.cpp
+++ b/NosoWalletCPP.cpp
@@ -101,7 +101,7 @@ void MainFrame::OnDownloadSummaryButtonClicked(wxCommandEvent& evt)
     GetSumaryText->SetLabel(wxString(GetZipSumaryResponse));              // Modify Static text to show Current Block
 
     wxString zipFileName = "summary.zip";
-    fs::path outputDir = fs::current_path() / "";
+    wxString outputDir = (fs::current_path() / "").string();
     UnzipFile(zipFileName, outputDir);
 
 

--- a/NosoWalletCPP.cpp
+++ b/NosoWalletCPP.cpp
@@ -28,9 +28,10 @@
 #include <botan/sha2_32.h>
 #include <botan/hex.h>
 #include <cctype>
+#include <filesystem>
 
 
-
+namespace fs = std::filesystem;
 
 
 
@@ -101,15 +102,15 @@ void MainFrame::OnDownloadSummaryButtonClicked(wxCommandEvent& evt)
     GetSumaryText->SetLabel(wxString(GetZipSumaryResponse));              // Modify Static text to show Current Block
     
     wxString zipFileName = "summary.zip";
-    wxString outputDir = ".\\";
+    std::string outputDir = fs::current_path() / "";
     UnzipFile(zipFileName, outputDir);
 
     
 
 
 
- 
-    std::ifstream inputFile(".\\data\\sumary.psk", std::ios::binary);
+    std::string filename = fs::current_path() / "data" / "sumary.psk";
+    std::ifstream inputFile(filename, std::ios::binary);
     if (!inputFile) {
         std::cout << "Cannot open the file." << std::endl;
         //return void; 

--- a/NosoWalletCPP.cpp
+++ b/NosoWalletCPP.cpp
@@ -108,7 +108,7 @@ void MainFrame::OnDownloadSummaryButtonClicked(wxCommandEvent& evt)
 
 
 
-    fs::path filename = fs::current_path() / "data" / "sumary.psk";
+    wxString filename = (fs::current_path() / "data" / "sumary.psk").string();
     std::ifstream inputFile(filename, std::ios::binary);
     if (!inputFile) {
         std::cout << "Cannot open the file." << std::endl;


### PR DESCRIPTION
Hey @Aniseto,

I've fixed the path issues with `data/sumary.psk`.

I've added:
```cpp
#include <filesystem>
namespace fs = std::filesystem;
```
and made some adjustments with the type of container for the path. From `wxString` to `std::string` which is what `current_path()` returns, I think...

> **Side Note**:
> The program is creating the `data` folder with permissiion `drw-r--r--`, when it should be `drwxrwxr-x`.
> This is a Linux only issue and I need to confer with @Azazorro to find a way to avoid/fix this.

Cheers,
Gus