### PR TITLE
Removing `clang` as the forced compiler chain

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,9 +16,7 @@
                 "CMAKE_TOOLCHAIN_FILE": {
                     "type": "FILEPATH",
                     "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-                },
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++"
+                }
             }
         }
     ],


### PR DESCRIPTION
Hey @Aniseto,

Somehow a change that I thought was already merged, wasn't.

This removes the forced choice of using `clang` as the compiler chain.

This will correct things, :crossed_fingers: !!!

Cheers,
Gus